### PR TITLE
Made 'role' and 'teamId' fields in User type nullable

### DIFF
--- a/src/schemas/users.js
+++ b/src/schemas/users.js
@@ -7,8 +7,8 @@ const usersTypeDefs = gql`
     lastName: String!
     email: String!
     password: String!
-    role: String!
-    teamId: Int!
+    role: String
+    teamId: Int
   }
   extend type Query {
     Users(teamId: Int!): [User]


### PR DESCRIPTION
### Description
Modified User type in GraphQL schema to have nullable 'role' and 'teamId' fields. This is to allow us to query User data on the frontend even if they currently aren't assigned a role/team.

### How to Test
- Run `docker-compose`
- Open up localhost:4000 to view the GraphQL playground
- Try querying for a User's teamId and role (should succeed even if the fields are null)