### PR TITLE
Adding Refresh Token Logic

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -39,7 +39,7 @@ const authenticateToken = (req, res, next) => {
         const refreshData = jwt.verify(refreshToken, refreshTokenSecret);
         const newAccessToken = createNewAccessToken(refreshData.userId);
 
-        res.cookie('access-token', newAccessToken);
+        addAccessTokenCookie(res, newAccessToken);
         req.userId = refreshData.userId;
       } catch (error) {
         console.log(error);
@@ -52,6 +52,26 @@ const authenticateToken = (req, res, next) => {
   next();
 };
 
+const addAccessTokenCookie = (res, accessToken) => {
+  res.cookie('access-token', accessToken);
+};
+
+const addRefreshTokenCookie = (res, refreshToken) => {
+  res.cookie('refresh-token', refreshToken);
+};
+
+const clearAccessTokenCookie = res => {
+  res.clearCookie('access-token');
+};
+
+const clearRefreshTokenCookie = res => {
+  res.clearCookie('refresh-token');
+};
+
 exports.authenticateToken = authenticateToken;
 exports.createNewAccessToken = createNewAccessToken;
 exports.createNewRefreshToken = createNewRefreshToken;
+exports.addAccessTokenCookie = addAccessTokenCookie;
+exports.addRefreshTokenCookie = addRefreshTokenCookie;
+exports.clearAccessTokenCookie = clearAccessTokenCookie;
+exports.clearRefreshTokenCookie = clearRefreshTokenCookie;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -14,41 +14,6 @@ const createNewAccessToken = userID => {
   });
 };
 
-const authenticateToken = (req, res, next) => {
-  try {
-    const accessToken = req.cookies['access-token'];
-    if (!accessToken) {
-      // eslint-disable-next-line no-console
-      console.log('Missing access token');
-    }
-    const accessData = jwt.verify(accessToken, ACCESS_TOKEN_SECRET);
-    req.userId = accessData.userId;
-  } catch (error) {
-    if (error.name === 'TokenExpiredError') {
-      //Generate a refresh token
-      try {
-        const refreshToken = req.cookies['refresh-token'];
-        if (!refreshToken) {
-          console.log('Missing refresh token');
-          return res.status(404).json({ error: 'Missing refresh token' });
-        }
-
-        const refreshData = jwt.verify(refreshToken, REFRESH_TOKEN_SECRET);
-        const newAccessToken = createNewAccessToken(refreshData.userId);
-
-        addAccessTokenCookie(res, newAccessToken);
-        req.userId = refreshData.userId;
-      } catch (error) {
-        console.log(error);
-      }
-    } else {
-      console.log(error);
-    }
-  }
-
-  next();
-};
-
 const addAccessTokenCookie = (res, accessToken) => {
   res.cookie('access-token', accessToken, {
     httpOnly: true,
@@ -71,6 +36,43 @@ const clearAccessTokenCookie = res => {
 
 const clearRefreshTokenCookie = res => {
   res.clearCookie('refresh-token');
+};
+
+const authenticateToken = (req, res, next) => {
+  try {
+    const accessToken = req.cookies['access-token'];
+    if (!accessToken) {
+      // eslint-disable-next-line no-console
+      console.log('Missing access token');
+    }
+    const accessData = jwt.verify(accessToken, ACCESS_TOKEN_SECRET);
+    req.userId = accessData.userId;
+  } catch (error) {
+    if (error.name === 'TokenExpiredError') {
+      // Generate a refresh token
+      try {
+        const refreshToken = req.cookies['refresh-token'];
+        if (!refreshToken) {
+          // eslint-disable-next-line no-console
+          console.log('Missing refresh token');
+        }
+
+        const refreshData = jwt.verify(refreshToken, REFRESH_TOKEN_SECRET);
+        const newAccessToken = createNewAccessToken(refreshData.userId);
+
+        addAccessTokenCookie(res, newAccessToken);
+        req.userId = refreshData.userId;
+      } catch (error2) {
+        // eslint-disable-next-line no-console
+        console.log(error2);
+      }
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  }
+
+  next();
 };
 
 exports.authenticateToken = authenticateToken;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -50,11 +50,19 @@ const authenticateToken = (req, res, next) => {
 };
 
 const addAccessTokenCookie = (res, accessToken) => {
-  res.cookie('access-token', accessToken);
+  res.cookie('access-token', accessToken, {
+    httpOnly: true,
+    sameSite: 'None',
+    secure: true,
+  });
 };
 
 const addRefreshTokenCookie = (res, refreshToken) => {
-  res.cookie('refresh-token', refreshToken);
+  res.cookie('refresh-token', refreshToken, {
+    httpOnly: true,
+    sameSite: 'None',
+    secure: true,
+  });
 };
 
 const clearAccessTokenCookie = res => {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -2,9 +2,6 @@ const jwt = require('jsonwebtoken');
 
 const { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } = require('../config/config');
 
-const accessTokenSecret = ACCESS_TOKEN_SECRET;
-const refreshTokenSecret = REFRESH_TOKEN_SECRET;
-
 const createNewRefreshToken = userID => {
   return jwt.sign({ userId: userID }, REFRESH_TOKEN_SECRET, {
     expiresIn: '7d',
@@ -24,7 +21,7 @@ const authenticateToken = (req, res, next) => {
       // eslint-disable-next-line no-console
       console.log('Missing access token');
     }
-    const accessData = jwt.verify(accessToken, accessTokenSecret);
+    const accessData = jwt.verify(accessToken, ACCESS_TOKEN_SECRET);
     req.userId = accessData.userId;
   } catch (error) {
     if (error.name === 'TokenExpiredError') {
@@ -36,7 +33,7 @@ const authenticateToken = (req, res, next) => {
           return res.status(404).json({ error: 'Missing refresh token' });
         }
 
-        const refreshData = jwt.verify(refreshToken, refreshTokenSecret);
+        const refreshData = jwt.verify(refreshToken, REFRESH_TOKEN_SECRET);
         const newAccessToken = createNewAccessToken(refreshData.userId);
 
         addAccessTokenCookie(res, newAccessToken);

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -5,6 +5,18 @@ const { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } = require('../config/config'
 const accessTokenSecret = ACCESS_TOKEN_SECRET;
 const refreshTokenSecret = REFRESH_TOKEN_SECRET;
 
+const createNewRefreshToken = userID => {
+  return jwt.sign({ userId: userID }, REFRESH_TOKEN_SECRET, {
+    expiresIn: '7d',
+  });
+};
+
+const createNewAccessToken = userID => {
+  return jwt.sign({ userId: userID }, ACCESS_TOKEN_SECRET, {
+    expiresIn: '1h',
+  });
+};
+
 const authenticateToken = (req, res, next) => {
   try {
     const accessToken = req.cookies['access-token'];
@@ -25,9 +37,8 @@ const authenticateToken = (req, res, next) => {
         }
 
         const refreshData = jwt.verify(refreshToken, refreshTokenSecret);
-        const newAccessToken = jwt.sign({ userId: refreshData.userId }, accessTokenSecret, {
-          expiresIn: '1h',
-        });
+        const newAccessToken = createNewAccessToken(refreshData.userId);
+
         res.cookie('access-token', newAccessToken);
         req.userId = refreshData.userId;
       } catch (error) {
@@ -42,3 +53,5 @@ const authenticateToken = (req, res, next) => {
 };
 
 exports.authenticateToken = authenticateToken;
+exports.createNewAccessToken = createNewAccessToken;
+exports.createNewRefreshToken = createNewRefreshToken;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -21,7 +21,7 @@ const authenticateToken = (req, res, next) => {
         const refreshToken = req.cookies['refresh-token'];
         if (!refreshToken) {
           console.log('Missing refresh token');
-          return;
+          return res.status(404).json({ error: 'Missing refresh token' });
         }
 
         const refreshData = jwt.verify(refreshToken, refreshTokenSecret);

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,44 @@
+const jwt = require('jsonwebtoken');
+
+const { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } = require('../config/config');
+
+const accessTokenSecret = ACCESS_TOKEN_SECRET;
+const refreshTokenSecret = REFRESH_TOKEN_SECRET;
+
+const authenticateToken = (req, res, next) => {
+  try {
+    const accessToken = req.cookies['access-token'];
+    if (!accessToken) {
+      // eslint-disable-next-line no-console
+      console.log('Missing access token');
+    }
+    const accessData = jwt.verify(accessToken, accessTokenSecret);
+    req.userId = accessData.userId;
+  } catch (error) {
+    if (error.name === 'TokenExpiredError') {
+      //Generate a refresh token
+      try {
+        const refreshToken = req.cookies['refresh-token'];
+        if (!refreshToken) {
+          console.log('Missing refresh token');
+          return;
+        }
+
+        const refreshData = jwt.verify(refreshToken, refreshTokenSecret);
+        const newAccessToken = jwt.sign({ userId: refreshData.userId }, accessTokenSecret, {
+          expiresIn: '1h',
+        });
+        res.cookie('access-token', newAccessToken);
+        req.userId = refreshData.userId;
+      } catch (error) {
+        console.log(error);
+      }
+    } else {
+      console.log(error);
+    }
+  }
+
+  next();
+};
+
+exports.authenticateToken = authenticateToken;

--- a/src/resolvers/auth.js
+++ b/src/resolvers/auth.js
@@ -45,7 +45,7 @@ const authResolvers = {
           expiresIn: '7d',
         });
         const accessToken = jwt.sign({ userId: user.id }, ACCESS_TOKEN_SECRET, {
-          expiresIn: '15min',
+          expiresIn: '1h',
         });
 
         res.cookie('refresh-token', refreshToken);

--- a/src/resolvers/auth.js
+++ b/src/resolvers/auth.js
@@ -1,8 +1,7 @@
 const bcrypt = require('bcryptjs');
-const jwt = require('jsonwebtoken');
 const models = require('../models');
 
-const { ACCESS_TOKEN_SECRET, REFRESH_TOKEN_SECRET } = require('../config/config');
+const { createNewAccessToken, createNewRefreshToken } = require('../middleware/auth');
 
 const authResolvers = {
   Query: {
@@ -41,12 +40,8 @@ const authResolvers = {
           return null;
         }
 
-        const refreshToken = jwt.sign({ userId: user.id }, REFRESH_TOKEN_SECRET, {
-          expiresIn: '7d',
-        });
-        const accessToken = jwt.sign({ userId: user.id }, ACCESS_TOKEN_SECRET, {
-          expiresIn: '1h',
-        });
+        const refreshToken = createNewRefreshToken(user.id);
+        const accessToken = createNewAccessToken(user.id);
 
         res.cookie('refresh-token', refreshToken);
         res.cookie('access-token', accessToken);

--- a/src/resolvers/auth.js
+++ b/src/resolvers/auth.js
@@ -1,7 +1,14 @@
 const bcrypt = require('bcryptjs');
 const models = require('../models');
 
-const { createNewAccessToken, createNewRefreshToken } = require('../middleware/auth');
+const {
+  createNewAccessToken,
+  createNewRefreshToken,
+  addAccessTokenCookie,
+  addRefreshTokenCookie,
+  clearAccessTokenCookie,
+  clearRefreshTokenCookie,
+} = require('../middleware/auth');
 
 const authResolvers = {
   Query: {
@@ -43,8 +50,8 @@ const authResolvers = {
         const refreshToken = createNewRefreshToken(user.id);
         const accessToken = createNewAccessToken(user.id);
 
-        res.cookie('refresh-token', refreshToken);
-        res.cookie('access-token', accessToken);
+        addAccessTokenCookie(res, accessToken);
+        addRefreshTokenCookie(res, refreshToken);
         return user;
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -53,8 +60,8 @@ const authResolvers = {
     },
     async logout(root, __, { req, res }) {
       try {
-        res.clearCookie('refresh-token');
-        res.clearCookie('access-token');
+        clearAccessTokenCookie(res);
+        clearRefreshTokenCookie(res);
         return true;
       } catch (error) {
         // eslint-disable-next-line no-console

--- a/src/server.js
+++ b/src/server.js
@@ -1,15 +1,13 @@
 const { ApolloServer } = require('apollo-server-express');
 const express = require('express');
 const cookieParser = require('cookie-parser');
-const { verify } = require('jsonwebtoken');
 
+const { authenticateToken } = require('./middleware/auth');
 const { schema } = require('./graphql');
 const models = require('./models');
 const routes = require('./routes');
-const { ACCESS_TOKEN_SECRET } = require('./config/config');
 
 const port = process.env.PORT || 4000;
-const accessTokenSecret = ACCESS_TOKEN_SECRET;
 
 const server = new ApolloServer({
   schema,
@@ -31,17 +29,7 @@ app.use(cookieParser());
 
 app.use('/shopify', routes);
 
-app.use((req, _, next) => {
-  const accessToken = req.cookies['access-token'];
-  try {
-    const data = verify(accessToken, accessTokenSecret);
-    req.userId = data.userId;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log(error);
-  }
-  next();
-});
+app.use(authenticateToken);
 
 server.applyMiddleware({ app, cors: corsOptions });
 


### PR DESCRIPTION
## Description

Link to ticket: https://www.notion.so/uwblueprintexecs/Auth-token-expires-in-like-5-minutes-or-somethign-short-like-that-4aff4fa550f24d1db9efadbf3a6e36a4 
https://www.notion.so/uwblueprintexecs/Cookies-do-not-work-on-prod-69f3a55f75e946e590e9f7310b4c78d8

## Approach

Added functionality of generating a new access token using the refresh token, when the current one has expired. 
Extracted token logic into a middleware file (auth.js).
Adding additional cookie options to ensure our cookies work on prod.

## Testing

* Pull these changes
* In src/middleware/auth.js line  to something short like '1s' 
* When you refresh the page (after 1 sec have passed) you should not be logged out, and in the console you'll see "Missing access token" logged. 
