### PR TITLE
Allow teamId to be null

### DIFF
--- a/src/migrations/20200926182637-create-user.js
+++ b/src/migrations/20200926182637-create-user.js
@@ -27,8 +27,7 @@ module.exports = {
         references: {
           model: 'Teams',
           key: 'id',
-        },
-        allowNull: false,
+        }
       },
       createdAt: {
         type: Sequelize.DATE,


### PR DESCRIPTION
On master, for some reason team Id cannot be null in the user model, but when someone makes an account team Id has to be null. At the moment you can't create a new account because of this.
