### PR TITLE
Sendgrid dynamic email templates

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -67,12 +67,10 @@ const authenticateToken = (req, res, next) => {
         addAccessTokenCookie(res, newAccessToken);
         req.userId = refreshData.userId;
       } catch (error2) {
-        // eslint-disable-next-line no-console
-        // console.log(error2);
+        // do nothing
       }
     } else {
-      // eslint-disable-next-line no-console
-      // console.log(error);
+      // do nothing
     }
   }
 

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -68,11 +68,11 @@ const authenticateToken = (req, res, next) => {
         req.userId = refreshData.userId;
       } catch (error2) {
         // eslint-disable-next-line no-console
-        console.log(error2);
+        // console.log(error2);
       }
     } else {
       // eslint-disable-next-line no-console
-      console.log(error);
+      // console.log(error);
     }
   }
 

--- a/src/services/sendEmail.js
+++ b/src/services/sendEmail.js
@@ -4,6 +4,8 @@ const sgMail = require('@sendgrid/mail');
 const { SENDGRID_API_KEY, CLIENT_URL, EMAIL_FROM_ADDRESS, EMAIL_REPLYTO_ADDRESS } = require('../config/config');
 const { DASHBOARD_ROOT_PATH } = require('../constants/client-routes');
 
+const VERIFY_EMAIL_TEMPLATE_ID = 'd-9446d43004094066ab95ae2f9e1ca623';
+
 sgMail.setApiKey(SENDGRID_API_KEY);
 
 const emailBase = {
@@ -14,16 +16,19 @@ const emailBase = {
   replyTo: EMAIL_REPLYTO_ADDRESS,
 };
 
-const createVerificationEmail = hash => {
+const createVerificationEmail = (name, hash) => {
   if (hash == null) {
     throw new Error('Null Hash');
   }
 
-  const inviteUrl = `${CLIENT_URL}/${DASHBOARD_ROOT_PATH}/verify/${hash}`;
+  const verifyEmailUrl = `${CLIENT_URL}/${DASHBOARD_ROOT_PATH}/verify/${hash}`;
 
   return {
-    subject: `Verify your email for Raising the Roof's Toque Campaign`,
-    html: `Thank you for signing up! Please verify your email <a href="${inviteUrl}">here</a>.`,
+    template_id: VERIFY_EMAIL_TEMPLATE_ID,
+    dynamic_template_data: {
+      verifyEmailUrl,
+      name,
+    },
   };
 };
 


### PR DESCRIPTION
## Description

[Link to ticket](https://www.notion.so/uwblueprintexecs/Building-Up-be1b30c321554bffba37a64c6cdc1ec6?p=fb8dee85d3454e24a484a994ab3f5b11)

Email copies: https://docs.google.com/document/d/1wKz2jnbcEHmtiwzEvC3XYRMF0XzNDlBH6PJcBY6z6Ps/edit

## Approach

You can see the dynamic templates if you sign into SendGrid. I followed https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/#send-a-transactional-email

## Testing

If you can, test out the 4 different emails (verify email, reset password, invite to team, leave team). If you don't have time, please just take a look at the code

## Screenshots

User removed from team:
![image](https://user-images.githubusercontent.com/26701004/116917191-529cc680-ac1c-11eb-8345-fbb161adcba9.png)

Invite user to team:
![image](https://user-images.githubusercontent.com/26701004/116917212-5a5c6b00-ac1c-11eb-87b7-72b416376ba7.png)

Verify your email address:
![image](https://user-images.githubusercontent.com/26701004/116917247-65170000-ac1c-11eb-8283-0f28c572a389.png)

Reset password:
![image](https://user-images.githubusercontent.com/26701004/116917280-72cc8580-ac1c-11eb-8b09-cc9b920f162b.png)

